### PR TITLE
Home page scroller correction

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -252,13 +252,13 @@ main {
       top: 0;
     }
     25% {
-      top: -26px;
+      top: -27px;
     }
     50% {
-      top: -51px;
+      top: -54px;
     }
     75% {
-      top: -75px;
+      top: -80px;
     }
   }
 


### PR DESCRIPTION
Home page scroller text was getting cut off. Made distance corrections so that when text scrolls the whole text can be seen when it stops, rather than getting cut off.