### PR TITLE
Logo link to home fix

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -66,7 +66,7 @@ header .img-wrap {
 
 header .img-link {
     display: flex;
-    width: inherit;
+    width: fit-content;
     height: auto;
 }
 


### PR DESCRIPTION
Logo link back to home page initially spanned across entire navigation bar on mobile and tablet. Changed the width of the link to be 'fit-content' instead of 'inherit'.