### PR TITLE
Huxi Yoga mockup bugs

### DIFF
--- a/work/huxi-yoga.html
+++ b/work/huxi-yoga.html
@@ -131,15 +131,15 @@
                 <div class="mockups">
                     <div class="mockup-holder">
                         <h5>Mobile</h5>
-                        <img class="mobile" src="/images/huxi/huxi-mockup-mobile.png" alt="Mobile mockup">
+                        <img class="mobile myImages myImg" src="/images/huxi/huxi-mockup-mobile.png" alt="Mobile mockup">
                     </div>
                     <div class="mockup-holder">
                         <h5>Tablet</h5>
-                        <img class="ipad" src="/images/huxi/huxi-mockup-ipad.png" alt="Tablet mockup">
+                        <img class="ipad myImages myImg" src="/images/huxi/huxi-mockup-ipad.png" alt="Tablet mockup">
                     </div>
                     <div class="mockup-holder">
                         <h5>Screen</h5>
-                        <img class="computer" src="/images/huxi/huxi-mockup-comp.png" alt="Screen mockup">
+                        <img class="computer myImages myImg" src="/images/huxi/huxi-mockup-comp.png" alt="Screen mockup">
                     </div>
                 </div>
             </div>  


### PR DESCRIPTION
Found that there were missing classes on the mockup images which is why they weren't opening up into modals when clicked. Added the classes onto the image tags.