### PR TITLE
Social media icons hover

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -695,28 +695,28 @@ footer .socials img {
 .socials .linkedin {
     background-image: url(/images/socials/linkedin.svg);
     background-repeat: no-repeat;
-    transition: background-image 0.5s, transform 0.5s;
+    transition: transform 0.5s;
     cursor: pointer;
 }
 
 .socials .instagram {
     background-image: url(/images/socials/instagram.svg);
     background-repeat: no-repeat;
-    transition: background-image 0.5s, transform 0.5s;
+    transition: transform 0.5s;
     cursor: pointer;
 }
 
 .socials .behance {
     background-image: url(/images/socials/behance.svg);
     background-repeat: no-repeat;
-    transition: background-image 0.5s, transform 0.5s;
+    transition: transform 0.5s;
     cursor: pointer;
 }
 
 .socials .dribbble {
     background-image: url(/images/socials/dribbble.svg);
     background-repeat: no-repeat;
-    transition: background-image 0.5s, transform 0.5s;
+    transition: transform 0.5s;
     cursor: pointer;
 }
 
@@ -1009,23 +1009,19 @@ footer {
         height: 65%;
     }
     .socials .linkedin:hover {
-        background-image: url(/images/socials/linkedin-hover.svg);
-        transform: scale(1.2);
+        transform: scale(1.25);
     }
     
     .socials .instagram:hover {
-        background-image: url(/images/socials/instagram-hover.svg);
-        transform: scale(1.2);
+        transform: scale(1.25);
     }
     
     .socials .behance:hover {
-        background-image: url(/images/socials/behance-hover.svg);
-        transform: scale(1.2);
+        transform: scale(1.25);
     }
     
     .socials .dribbble:hover {
-        background-image: url(/images/socials/dribbble-hover.svg);
-        transform: scale(1.2);
+        transform: scale(1.25);
     }
     .featured:hover {
         background-color: #E6E6E6;


### PR DESCRIPTION
Removed the hover effect of loading the new image. After some research I found that the social icons disappear on initial hover because the website needs to load this new asset onto the screen. For this reason I removed the image hover effect and increased the scale effect slightly so that the user could easily tell that the link is clickable.