### PR TITLE
contact page empty space

### DIFF
--- a/styles/contact.css
+++ b/styles/contact.css
@@ -244,6 +244,9 @@ main {
         padding: 40px 20px 20px;
         align-items: flex-start;
     }
+    main {
+      margin-top: 20vh;
+  }
 }
 
 
@@ -263,4 +266,7 @@ main {
     .profile-pic img {
         width: 70%;
       }
+    main {
+        margin-top: 15vh;
+    }
 }


### PR DESCRIPTION
Added new breakpoints for the margin top of main. This is so that there is more of a balanced space between the top and bottom so that the footer is being pushed to the bottom for no reason. The contact page is something that I will be wanting to move onto the home page for a later iteration of my portfolio.